### PR TITLE
START : added the basic docker file required for containerization

### DIFF
--- a/ExpenseManager/Dockerfile
+++ b/ExpenseManager/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:17-jdk-alpine
+VOLUME /tmp
+COPY target/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
**Detailed changes**
- Added a basic docker file
  - Base image :  eclipse-temurin
  - JDK version been used : :17-jdk-alpine

**Actions before running**
- Check if current version  of JDK i.e. version > 17 was added to the class path
- run the command ./mvnw install
- build the image
 ex :- docker build -t exp-mngr-app .
  - name of the image **exp-mngr-app** 
- run the container by mapping the container port 8081 (since specified in applicatoin.properties) to any local port
 ex :- docker run -p 8082:8081 exp-mngr-app
  - local port : 8082
  - container port : 8081